### PR TITLE
Fix CI and add tests

### DIFF
--- a/docs/examples/example_sparse_inputs.ipynb
+++ b/docs/examples/example_sparse_inputs.ipynb
@@ -20,42 +20,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style type='text/css'>\n",
-       ".datatable table.frame { margin-bottom: 0; }\n",
-       ".datatable table.frame thead { border-bottom: none; }\n",
-       ".datatable table.frame tr.coltypes td {  color: #FFFFFF;  line-height: 6px;  padding: 0 0.5em;}\n",
-       ".datatable .bool    { background: #DDDD99; }\n",
-       ".datatable .object  { background: #565656; }\n",
-       ".datatable .int     { background: #5D9E5D; }\n",
-       ".datatable .float   { background: #4040CC; }\n",
-       ".datatable .str     { background: #CC4040; }\n",
-       ".datatable .time    { background: #40CC40; }\n",
-       ".datatable .row_index {  background: var(--jp-border-color3);  border-right: 1px solid var(--jp-border-color0);  color: var(--jp-ui-font-color3);  font-size: 9px;}\n",
-       ".datatable .frame tbody td { text-align: left; }\n",
-       ".datatable .frame tr.coltypes .row_index {  background: var(--jp-border-color0);}\n",
-       ".datatable th:nth-child(2) { padding-left: 12px; }\n",
-       ".datatable .hellipsis {  color: var(--jp-cell-editor-border-color);}\n",
-       ".datatable .vellipsis {  background: var(--jp-layout-color0);  color: var(--jp-cell-editor-border-color);}\n",
-       ".datatable .na {  color: var(--jp-cell-editor-border-color);  font-size: 80%;}\n",
-       ".datatable .sp {  opacity: 0.25;}\n",
-       ".datatable .footer { font-size: 9px; }\n",
-       ".datatable .frame_dimensions {  background: var(--jp-border-color3);  border-top: 1px solid var(--jp-border-color0);  color: var(--jp-ui-font-color3);  display: inline-block;  opacity: 0.6;  padding: 1px 10px 1px 5px;}\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import time, psutil, os, gc\n",
     "import numpy as np\n",
@@ -68,12 +35,15 @@
     "from sklearn.metrics import mean_squared_error, r2_score\n",
     "\n",
     "from lightgbm import LGBMRegressor, LGBMClassifier\n",
-    "from metalearners import DRLearner"
+    "from metalearners import DRLearner\n",
+    "\n",
+    "# This is required for when nbconvert converts the cell-magic to regular function calls.\n",
+    "from IPython import get_ipython"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,19 +154,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Sparse data memory: 7.63MB\n",
-      "Dense data memory: 953.64MB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"\\nSparse data memory: {X_csr.data.nbytes / 1024 / 1024:.2f}MB\")\n",
     "print(f\"Dense data memory: {X_np.nbytes / 1024 / 1024:.2f}MB\")"
@@ -211,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,20 +209,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gc.collect()"
    ]
@@ -276,28 +225,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparse data - Runtime: 15.04s, Memory used: 324.86MB\n",
-      "(array([0.9523358]), array([0.0202085]))\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "318"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fit_drlearner_wrapper(X_csr)\n",
     "gc.collect()"
@@ -312,28 +242,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparse data - Runtime: 117.22s, Memory used: 87.21MB\n",
-      "(array([0.95124745]), array([0.02021724]))\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "190"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fit_drlearner_wrapper(X_np)\n",
     "gc.collect()"
@@ -357,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,28 +349,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 1min 4s, sys: 1.83 s, total: 1min 5s\n",
-      "Wall time: 8.6 s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "39"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "sparse_runtime, sparse_memory, sparse_mse, sparse_r2 = fit_and_measure(X_train_sparse, y_train, X_test_sparse, y_test)\n",
@@ -468,28 +360,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 2min 50s, sys: 6.88 s, total: 2min 57s\n",
-      "Wall time: 31.6 s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "35"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "dense_runtime, dense_memory, dense_mse, dense_r2 = fit_and_measure(X_train_dense, y_train, X_test_dense, y_test)\n",
@@ -498,37 +371,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparse data - Runtime: 8.48s, Memory used: 69.88MB, MSE: 0.8659, R2: 0.1396\n",
-      "Dense data - Runtime: 30.58s, Memory used: 1.21MB, MSE: 0.8659, R2: 0.1396\n",
-      "\n",
-      "Sparse data memory: 12.21MB\n",
-      "Dense data memory: 1525.88MB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# Mypy can't find these names/variables since they are assigned to via cell-magic.\n",
     "print(\n",
-    "    f\"Sparse data - Runtime: {sparse_runtime:.2f}s, Memory used: {sparse_memory:.2f}MB, MSE: {sparse_mse:.4f}, R2: {sparse_r2:.4f}\"\n",
-    ")\n",
+    "    f\"Sparse data - Runtime: {sparse_runtime:.2f}s, \"  # type: ignore[name-defined]\n",
+    "    f\"Memory used: {sparse_memory:.2f}MB, \"  # type: ignore[name-defined]\n",
+    "    f\"MSE: {sparse_mse:.4f}, R2: {sparse_r2:.4f}\"  # type: ignore[name-defined]\n",
+    ") \n",
     "print(\n",
-    "    f\"Dense data - Runtime: {dense_runtime:.2f}s, Memory used: {dense_memory:.2f}MB, MSE: {dense_mse:.4f}, R2: {dense_r2:.4f}\"\n",
+    "    f\"Dense data - Runtime: {dense_runtime:.2f}s, \"  # type: ignore[name-defined]\n",
+    "    f\"Memory used: {dense_memory:.2f}MB, \"  # type: ignore[name-defined]\n",
+    "    f\"MSE: {dense_mse:.4f}, R2: {dense_r2:.4f}\"  # type: ignore[name-defined]\n",
     ")\n",
     "\n",
     "print(f\"\\nSparse data memory: {X_train_sparse.data.nbytes / 1024 / 1024:.2f}MB\")\n",
     "print(f\"Dense data memory: {X_train_dense.nbytes / 1024 / 1024:.2f}MB\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py311",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -542,9 +415,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/test_cross_fit_estimator.py
+++ b/tests/test_cross_fit_estimator.py
@@ -54,7 +54,7 @@ def test_crossfitestimator_oos_smoke(
     if backend == "np":
         X = X.to_numpy()
         y = y.to_numpy()
-    if backend == "csr":
+    elif backend == "csr":
         X = csr_matrix(df.values)
         y = y.to_numpy()
 

--- a/tests/test_cross_fit_estimator.py
+++ b/tests/test_cross_fit_estimator.py
@@ -6,6 +6,7 @@ from functools import partial
 import numpy as np
 import pytest
 from lightgbm import LGBMClassifier, LGBMRegressor
+from scipy.sparse import csr_matrix
 from sklearn.base import is_classifier, is_regressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import accuracy_score, log_loss
@@ -24,10 +25,10 @@ _SEED = 1337
 @pytest.mark.parametrize("predict_proba", [True, False])
 @pytest.mark.parametrize("is_oos", [True, False])
 @pytest.mark.parametrize("oos_method", ["overall", "mean", "median"])
-@pytest.mark.parametrize("use_np", [True, False])
+@pytest.mark.parametrize("backend", ["np", "pd", "csr"])
 @pytest.mark.parametrize("pass_cv", [True, False])
 def test_crossfitestimator_oos_smoke(
-    mindset_data, rng, use_clf, predict_proba, is_oos, oos_method, use_np, pass_cv
+    mindset_data, rng, use_clf, predict_proba, is_oos, oos_method, backend, pass_cv
 ):
     if not use_clf and predict_proba:
         pytest.skip()
@@ -50,8 +51,11 @@ def test_crossfitestimator_oos_smoke(
         # Arbitrary cut-off
         y = y > 0.8
 
-    if use_np:
+    if backend == "np":
         X = X.to_numpy()
+        y = y.to_numpy()
+    if backend == "csr":
+        X = csr_matrix(df.values)
         y = y.to_numpy()
 
     cfe = CrossFitEstimator(

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from lightgbm import LGBMClassifier, LGBMRegressor
+from scipy.sparse import csr_matrix
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import make_scorer, root_mean_squared_error
 from sklearn.model_selection import train_test_split
@@ -939,16 +940,18 @@ def test_model_reusage(outcome_kind, request):
         ),
     ],
 )
-@pytest.mark.parametrize("use_pandas", [False, True])
-def test_evaluate_feature_set_smoke(metalearner_factory, feature_set, rng, use_pandas):
+@pytest.mark.parametrize("backend", ["np", "pd", "csr"])
+def test_evaluate_feature_set_smoke(metalearner_factory, feature_set, rng, backend):
     n_samples = 100
     X = rng.standard_normal((n_samples, 5))
     y = rng.standard_normal(n_samples)
     w = rng.integers(0, 2, n_samples)
-    if use_pandas:
+    if backend == "pd":
         X = pd.DataFrame(X)
         y = pd.Series(y)
         w = pd.Series(w)
+    elif backend == "csr":
+        X = csr_matrix(X)
 
     ml = metalearner_factory(
         n_variants=2,


### PR DESCRIPTION
This PR adds a couple of changes to the metalearners [PR 86](https://github.com/Quantco/metalearners/pull/86).

- The CI job running mypy against the example notebooks fails. This should be addressed by manually importing `get_ipython` as well as telling mypy to ignore cell-magic related variables (https://github.com/Quantco/metalearners/actions/runs/10427273483/job/28881687172?pr=86)
- Enables all tests which were previously run against `pandas` and `numpy` datastructures to also run against `csr_matrix` instances from `scipy.sparse`.

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
